### PR TITLE
Set EmailUser.Meta.swappable to 'AUTH_USER_MODEL'

### DIFF
--- a/custom_user/models.py
+++ b/custom_user/models.py
@@ -92,4 +92,5 @@ class EmailUser(AbstractEmailUser):
 
     Use this if you don't need to extend EmailUser.
     """
-    pass
+    class Meta:
+        swappable = 'AUTH_USER_MODEL'


### PR DESCRIPTION
Without this set creating a custom user from AbstractEmailUser models
would not validate when using Django 1.6c1. Django 1.5 was no problem.
Should this reported up stream?

Signed-off-by: Simon Luijk simon@simonluijk.com
