### PR TITLE
Add initial migration

### DIFF
--- a/custom_user/migrations/0001_initial.py
+++ b/custom_user/migrations/0001_initial.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EmailUser',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(null=True, verbose_name='last login', blank=True)),
+                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
+                ('email', models.EmailField(unique=True, max_length=255, verbose_name='email address', db_index=True)),
+                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
+                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
+            ],
+            options={
+                'abstract': False,
+                'verbose_name': 'user',
+                'swappable': 'AUTH_USER_MODEL',
+                'verbose_name_plural': 'users',
+            },
+        ),
+    ]

--- a/custom_user/migrations/0001_initial.py
+++ b/custom_user/migrations/0001_initial.py
@@ -8,7 +8,7 @@ import django.utils.timezone
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('auth', '0006_require_contenttypes_0002'),
+        ('auth', '0001_initial'),
     ]
 
     operations = [

--- a/pylama.ini
+++ b/pylama.ini
@@ -5,3 +5,6 @@ path = custom_user
 [pylama:custom_user/tests.py]
 # Ignore "Docstring missing" in class and methods, and "line too long"
 ignore = D101,D102,E501
+
+[pylama:custom_user/migrations/*]
+skip = 1


### PR DESCRIPTION
Without an initial migrations, a brand new project will fail to `syncdb` or `migrate` properly since `auth_group` will not have been created yet.

See <https://docs.djangoproject.com/en/1.8/topics/migrations/#dependencies> for more information.