### PR TITLE
Add migrations for Django 1.8.

### DIFF
--- a/custom_user/apps.py
+++ b/custom_user/apps.py
@@ -1,5 +1,8 @@
 """App configuration for custom_user."""
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+from .signals import remove_empty_migration_on_django_17
 
 
 class CustomUserConfig(AppConfig):
@@ -8,3 +11,6 @@ class CustomUserConfig(AppConfig):
 
     name = 'custom_user'
     verbose_name = "Custom User"
+
+    def ready(self):
+        post_migrate.connect(remove_empty_migration_on_django_17, sender=self)

--- a/custom_user/migrations/0001_initial.py
+++ b/custom_user/migrations/0001_initial.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EmailUser',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(default=django.utils.timezone.now, verbose_name='last login')),
+                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
+                ('email', models.EmailField(unique=True, max_length=255, verbose_name='email address', db_index=True)),
+                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
+                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of his/her group.', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
+            ],
+            options={
+                'abstract': False,
+                'verbose_name': 'user',
+                'swappable': 'AUTH_USER_MODEL',
+                'verbose_name_plural': 'users',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/custom_user/migrations/0002_django_18_changes.py
+++ b/custom_user/migrations/0002_django_18_changes.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import django
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('custom_user', '0001_initial'),
+    ]
+
+    operations = [] if django.VERSION < (1, 8) else [
+        migrations.AlterField(
+            model_name='emailuser',
+            name='email',
+            field=models.EmailField(unique=True, max_length=254, verbose_name='email address', db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='emailuser',
+            name='groups',
+            field=models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups'),
+        ),
+        migrations.AlterField(
+            model_name='emailuser',
+            name='last_login',
+            field=models.DateTimeField(null=True, verbose_name='last login', blank=True),
+        ),
+    ]

--- a/custom_user/models.py
+++ b/custom_user/models.py
@@ -77,7 +77,7 @@ class AbstractEmailUser(AbstractBaseUser, PermissionsMixin):
 
     """
 
-    email = models.EmailField(_('email address'), max_length=255,
+    email = models.EmailField(_('email address'), max_length=254,
                               unique=True, db_index=True)
     is_staff = models.BooleanField(
         _('staff status'), default=False, help_text=_(

--- a/custom_user/signals.py
+++ b/custom_user/signals.py
@@ -1,0 +1,12 @@
+import django
+from django.db import connection
+from django.db.migrations.recorder import MigrationRecorder
+
+django_18_migration = '0002_django_18_changes'
+
+
+def remove_empty_migration_on_django_17(sender, **kwargs):
+    if django.VERSION < (1, 8):
+        migration_recorder = MigrationRecorder(connection)
+        if (sender.name, django_18_migration) in migration_recorder.applied_migrations():
+            migration_recorder.record_unapplied(sender.name, django_18_migration)

--- a/pylama.ini
+++ b/pylama.ini
@@ -5,3 +5,6 @@ path = custom_user
 [pylama:custom_user/tests.py]
 # Ignore "Docstring missing" in class and methods, and "line too long"
 ignore = D101,D102,E501
+
+[pylama:custom_user/migrations/*]
+skip = 1


### PR DESCRIPTION
I needed this migration for Django 1.8. I don't know know how to set this up to run only on 1.8 and not on 1.7.

I also modified the max_length of the email field to match Django which is the official max size for email addresses. 

You need to run this with:

```
./manage.py migrate --fake-initial
```

Thanks!