### PR TITLE
Fixing a 'BoundField' error. 

### DIFF
--- a/custom_user/models.py
+++ b/custom_user/models.py
@@ -27,7 +27,7 @@ class EmailUserManager(BaseUserManager):
         now = timezone.now()
         if not email:
             raise ValueError('The given email must be set')
-        email = self.normalize_email(email)
+        email = self.normalize_email(email.data)
         is_active = extra_fields.pop("is_active", True)
         user = self.model(email=email, is_staff=is_staff, is_active=is_active,
                           is_superuser=is_superuser, last_login=now,


### PR DESCRIPTION
Apparently in 1.9 the email has to be normalized only at the data property. Or else you can get a nasty BoundField has no *whatever I can't remember* property