### PR TITLE
Add missing Python versions in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     services:
       mysql:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py37,py38,py39,py310}-django{32,40,master}-{mysql,postgres,sqlite}, pylama
+envlist = py37-django32-{mysql,postgres,sqlite}, {py38,py39,py310}-django{32,40,master}-{mysql,postgres,sqlite}, pylama
 
 [gh-actions]
 python =


### PR DESCRIPTION
Python 3.7 was not defined in the workflow.