### PR TITLE
Import latest code changes from Django 4.0

### DIFF
--- a/src/custom_user/admin.py
+++ b/src/custom_user/admin.py
@@ -7,9 +7,11 @@ from .forms import EmailUserChangeForm, EmailUserCreationForm
 from .models import EmailUser
 
 
+@admin.register(EmailUser)
 class EmailUserAdmin(UserAdmin):
-
-    """EmailUser Admin model."""
+    """
+    EmailUser Admin model.
+    """
 
     fieldsets = (
         (None, {"fields": ("email", "password")}),
@@ -22,13 +24,19 @@ class EmailUserAdmin(UserAdmin):
                     "is_superuser",
                     "groups",
                     "user_permissions",
-                )
+                ),
             },
         ),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
     add_fieldsets = (
-        (None, {"classes": ("wide",), "fields": ("email", "password1", "password2")}),
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": ("email", "password1", "password2"),
+            },
+        ),
     )
 
     # The forms to add and change user instances
@@ -46,7 +54,3 @@ class EmailUserAdmin(UserAdmin):
         "groups",
         "user_permissions",
     )
-
-
-# Register the new EmailUserAdmin
-admin.site.register(EmailUser, EmailUserAdmin)

--- a/src/custom_user/apps.py
+++ b/src/custom_user/apps.py
@@ -3,8 +3,9 @@ from django.apps import AppConfig
 
 
 class CustomUserConfig(AppConfig):
-
-    """Default configuration for custom_user."""
+    """
+    Default configuration for custom_user.
+    """
 
     name = "custom_user"
     verbose_name = "Custom User"

--- a/src/custom_user/forms.py
+++ b/src/custom_user/forms.py
@@ -1,17 +1,16 @@
 """EmailUser forms."""
 from django import forms
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, password_validation
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
+from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 
 class EmailUserCreationForm(forms.ModelForm):
-
     """
     A form for creating new users.
 
     Includes all the required fields, plus a repeated password.
-
     """
 
     error_messages = {
@@ -19,14 +18,20 @@ class EmailUserCreationForm(forms.ModelForm):
         "password_mismatch": _("The two password fields didn't match."),
     }
 
-    password1 = forms.CharField(label=_("Password"), widget=forms.PasswordInput)
+    password1 = forms.CharField(
+        label=_("Password"),
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        help_text=password_validation.password_validators_help_text_html(),
+    )
     password2 = forms.CharField(
         label=_("Password confirmation"),
-        widget=forms.PasswordInput,
-        help_text=_("Enter the same password as above, for verification."),
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        strip=False,
+        help_text=_("Enter the same password as before, for verification."),
     )
 
-    class Meta:  # noqa: D101
+    class Meta:
         model = get_user_model()
         fields = ("email",)
 
@@ -35,8 +40,7 @@ class EmailUserCreationForm(forms.ModelForm):
         Clean form email.
 
         :return str email: cleaned email
-        :raise forms.ValidationError: Email is duplicated
-
+        :raise ValidationError: Email is duplicated
         """
         # Since EmailUser.email is unique, this check is redundant,
         # but it sets a nicer error message than the ORM. See #13147.
@@ -45,7 +49,7 @@ class EmailUserCreationForm(forms.ModelForm):
             get_user_model()._default_manager.get(email=email)
         except get_user_model().DoesNotExist:
             return email
-        raise forms.ValidationError(
+        raise ValidationError(
             self.error_messages["duplicate_email"],
             code="duplicate_email",
         )
@@ -55,17 +59,27 @@ class EmailUserCreationForm(forms.ModelForm):
         Check that the two password entries match.
 
         :return str password2: cleaned password2
-        :raise forms.ValidationError: password2 != password1
-
+        :raise ValidationError: password2 != password1
         """
         password1 = self.cleaned_data.get("password1")
         password2 = self.cleaned_data.get("password2")
         if password1 and password2 and password1 != password2:
-            raise forms.ValidationError(
+            raise ValidationError(
                 self.error_messages["password_mismatch"],
                 code="password_mismatch",
             )
         return password2
+
+    def _post_clean(self):
+        super()._post_clean()
+        # Validate the password after self.instance is updated with form data
+        # by super().
+        password = self.cleaned_data.get("password2")
+        if password:
+            try:
+                password_validation.validate_password(password, self.instance)
+            except ValidationError as error:
+                self.add_error("password2", error)
 
     def save(self, commit=True):
         """
@@ -74,9 +88,8 @@ class EmailUserCreationForm(forms.ModelForm):
         Save the provided password in hashed format.
 
         :return custom_user.models.EmailUser: user
-
         """
-        user = super(EmailUserCreationForm, self).save(commit=False)
+        user = super().save(commit=False)
         user.set_password(self.cleaned_data["password1"])
         if commit:
             user.save()
@@ -90,39 +103,28 @@ class EmailUserChangeForm(forms.ModelForm):
 
     Includes all the fields on the user, but replaces the password field
     with admin's password hash display field.
-
     """
 
     password = ReadOnlyPasswordHashField(
         label=_("Password"),
         help_text=_(
-            "Raw passwords are not stored, so there is no way to see "
-            "this user's password, but you can change the password "
-            'using <a href="%(url)s">this form</a>.'
-        )
-        % {"url": "../password/"},
+            "Raw passwords are not stored, so there is no way to see this "
+            "user's password, but you can change the password using "
+            '<a href="{}">this form</a>.'
+        ),
     )
 
-    class Meta:  # noqa: D101
+    class Meta:
         model = get_user_model()
         exclude = ()
 
     def __init__(self, *args, **kwargs):
-        """Init the form."""
-        super(EmailUserChangeForm, self).__init__(*args, **kwargs)
-        f = self.fields.get("user_permissions", None)
-        if f is not None:
-            f.queryset = f.queryset.select_related("content_type")
-
-    def clean_password(self):
-        """
-        Clean password.
-
-        Regardless of what the user provides, return the initial value.
-        This is done here, rather than on the field, because the
-        field does not have access to the initial value.
-
-        :return str password:
-
-        """
-        return self.initial["password"]
+        super().__init__(*args, **kwargs)
+        password = self.fields.get("password")
+        if password:
+            password.help_text = password.help_text.format("../password/")
+        user_permissions = self.fields.get("user_permissions")
+        if user_permissions:
+            user_permissions.queryset = user_permissions.queryset.select_related(
+                "content_type"
+            )

--- a/src/custom_user/models.py
+++ b/src/custom_user/models.py
@@ -11,8 +11,9 @@ from django.utils.translation import gettext_lazy as _
 
 
 class EmailUserManager(BaseUserManager):
-
-    """Custom manager for EmailUser."""
+    """
+    Custom manager for EmailUser.
+    """
 
     def _create_user(self, email, password, is_staff, is_superuser, **extra_fields):
         """
@@ -24,7 +25,6 @@ class EmailUserManager(BaseUserManager):
         :param bool is_superuser: whether user admin or not
         :return custom_user.models.EmailUser user: user
         :raise ValueError: email is not set
-
         """
         now = timezone.now()
         if not email:
@@ -51,25 +51,31 @@ class EmailUserManager(BaseUserManager):
         :param str email: user email
         :param str password: user password
         :return custom_user.models.EmailUser user: regular user
-
         """
-        is_staff = extra_fields.pop("is_staff", False)
-        return self._create_user(email, password, is_staff, False, **extra_fields)
+        extra_fields.setdefault("is_staff", False)
+        extra_fields.setdefault("is_superuser", False)
+        return self._create_user(email, password, **extra_fields)
 
-    def create_superuser(self, email, password, **extra_fields):
+    def create_superuser(self, email, password=None, **extra_fields):
         """
         Create and save an EmailUser with the given email and password.
 
         :param str email: user email
         :param str password: user password
         :return custom_user.models.EmailUser user: admin user
-
         """
-        return self._create_user(email, password, True, True, **extra_fields)
+        extra_fields.setdefault("is_staff", True)
+        extra_fields.setdefault("is_superuser", True)
+
+        if extra_fields.get("is_staff") is not True:
+            raise ValueError("Superuser must have is_staff=True.")
+        if extra_fields.get("is_superuser") is not True:
+            raise ValueError("Superuser must have is_superuser=True.")
+
+        return self._create_user(email, password, **extra_fields)
 
 
 class AbstractEmailUser(AbstractBaseUser, PermissionsMixin):
-
     """
     Abstract User with the same behaviour as Django's default User.
 
@@ -84,7 +90,6 @@ class AbstractEmailUser(AbstractBaseUser, PermissionsMixin):
         * password
         * last_login
         * is_superuser
-
     """
 
     email = models.EmailField(
@@ -110,7 +115,7 @@ class AbstractEmailUser(AbstractBaseUser, PermissionsMixin):
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS = []
 
-    class Meta:  # noqa: D101
+    class Meta:
         verbose_name = _("user")
         verbose_name_plural = _("users")
         abstract = True
@@ -129,13 +134,11 @@ class AbstractEmailUser(AbstractBaseUser, PermissionsMixin):
 
 
 class EmailUser(AbstractEmailUser):
-
     """
     Concrete class of AbstractEmailUser.
 
     Use this if you don't need to extend EmailUser.
-
     """
 
-    class Meta(AbstractEmailUser.Meta):  # noqa: D101
+    class Meta(AbstractEmailUser.Meta):
         swappable = "AUTH_USER_MODEL"

--- a/test_settings/settings_subclass.py
+++ b/test_settings/settings_subclass.py
@@ -1,6 +1,6 @@
-from .settings import *
+from .settings import *  # NOQA: F403
 
-INSTALLED_APPS += [
+INSTALLED_APPS += [  # NOQA: F405
     "test_custom_user_subclass",
 ]
 AUTH_USER_MODEL = "test_custom_user_subclass.MyCustomEmailUser"


### PR DESCRIPTION
Used the current stable version of Django (4.0) as the reference for all the changes.

It includes, among other things:

- `EmailUserCreationForm` does not strip whitespaces in the password fields, to match Django's behavior.
- `EmailUserCreationForm` supports custom password validators configured by `AUTH_PASSWORD_VALIDATORS`.
- `EmailUser.objects.create_superuser()` allows empty passwords. It will also check that both `is_staff` and `is_superuser` parameters are `True` (if passed). Otherwise, it would create an invalid superuser.