### PR TITLE
Faster github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,6 @@ jobs:
         result = "{}-{}-{}".format(python_version, django_version, database_version)
         print("::set-output name=result::{}".format(result))
 
-    - name: Run tox targets for ${{ matrix.python-version }}
+    - name: Run tox for ${{ steps.tox-environment-name.outputs.result }}
       run: |
-        poetry run tox -e ${{ steps.tox-environment-name.outputs.result }}
+        poetry run tox -e '${{ steps.tox-environment-name.outputs.result }}'


### PR DESCRIPTION
Will run one job per tox environment instead of one job per python version.